### PR TITLE
Optimize the CPU implementation of searchsorted

### DIFF
--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -33,8 +33,14 @@ def get_tensors(device):
     a = torch.sort(torch.randn(B, A, device=device), dim=1)[0]
     v = torch.randn(B, V, device=device)
     out = torch.empty(B, V, device=device, dtype=torch.long)
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
     return a, v, out
 
+def searchsorted_synchronized(a,v,out=None,side='left'):
+    out = searchsorted(a,v,out,side)
+    torch.cuda.synchronize()
+    return out
 
 numpy = timeit.repeat(
     stmt="numpy_searchsorted(a, v, side='left')",

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -62,7 +62,7 @@ print('CPU: ', min(cpu), sep='\t')
 
 if torch.cuda.is_available():
     gpu = timeit.repeat(
-        stmt="searchsorted(a, v, out, side='left')",
+        stmt="searchsorted_synchronized(a, v, out, side='left')",
         setup="a, v, out = get_tensors(device='cuda')",
         globals=globals(),
         repeat=repeats,

--- a/examples/test.py
+++ b/examples/test.py
@@ -52,10 +52,11 @@ if __name__ == '__main__':
             # now do the CPU
             a = a.to('cuda')
             v = v.to('cuda')
-
+            torch.cuda.synchronize()
             # launch searchsorted on those
             t0 = time.time()
             test_GPU = searchsorted(a, v, test_GPU, side)
+            torch.cuda.synchronize()
             print('GPU:  searchsorted in %0.3fms' % (1000*(time.time()-t0)))
 
             # compute the difference between both

--- a/src/cpu/searchsorted_cpu_wrapper.cpp
+++ b/src/cpu/searchsorted_cpu_wrapper.cpp
@@ -101,6 +101,7 @@ void searchsorted_cpu_wrapper(
 
       scalar_t* a_data = a.data_ptr<scalar_t>();
       scalar_t* v_data = v.data_ptr<scalar_t>();
+      int64_t* res_data = res.data<int64_t>();
 
       for (int64_t row = 0; row < nrow_res; row++)
       {
@@ -114,7 +115,7 @@ void searchsorted_cpu_wrapper(
               int64_t idx_in_res = row * ncol_v + col;
 
               // apply binary search
-              res.data<int64_t>()[idx_in_res] = (binary_search(a_data, row_in_a, v_data[idx_in_v], ncol_a, side_left) + 1);
+              res_data[idx_in_res] = (binary_search(a_data, row_in_a, v_data[idx_in_v], ncol_a, side_left) + 1);
           }
       }
       });


### PR DESCRIPTION
This PR includes:

- Changes to the CPU implementation of searchsorted that should make it run faster
- Changes to the benchmarking code so that it benchmarks the time it takes to run on the GPU more accurately, by waiting for the threads to finish running before taking the time.

Please, run the benchmarks, at least on my machine, the measured time for CPU is faster, while the measured time for GPU is slower, as it now should measure the time it takes for the kernel to finish running, instead of just to start.

On my machine, I got for benchmark.py:
Numpy:  6.002121
CPU:    3.8862431
CUDA:   0.09661